### PR TITLE
Fix mpi parallelization and some load balancing

### DIFF
--- a/lya_2pt/cosmo.py
+++ b/lya_2pt/cosmo.py
@@ -183,7 +183,7 @@ class PiccaCosmo():
         H0 = 100.0
         SPEED_LIGHT = speed_of_light / 1000
 
-        print(f"Om={Om}, Or={Or}, wl={wl}")
+        # print(f"Om={Om}, Or={Or}, wl={wl}")
 
         # Ignore evolution of neutrinos from matter to radiation
         Ol = 1. - Ok - Om - Or

--- a/lya_2pt/interface.py
+++ b/lya_2pt/interface.py
@@ -7,7 +7,7 @@ import tqdm
 import lya_2pt.global_data as globals
 from lya_2pt.correlation import compute_xi
 from lya_2pt.distortion import compute_dmat
-from lya_2pt.optimal_estimator import compute_xi_and_fisher
+from lya_2pt.optimal_estimator import compute_xi_and_fisher, compute_num_pairs
 from lya_2pt.cosmo import Cosmology
 from lya_2pt.forest_healpix_reader import ForestHealpixReader
 from lya_2pt.tracer2_reader import Tracer2Reader
@@ -120,7 +120,7 @@ class Interface:
         self.export = Export(
             config["export"], self.output.name, self.output.output_directory, self.num_cpu)
 
-    def read_tracers(self, files=None):
+    def read_tracers(self, files=None, mpi_rank=0):
         """Read the tracers
 
         Arguments
@@ -133,7 +133,9 @@ class Interface:
 
         if self.num_cpu > 1:
             with multiprocessing.Pool(processes=self.num_cpu) as pool:
-                results = list(tqdm.tqdm(pool.imap(self.read_tracer1, files), total=len(files)))
+                results = list(tqdm.tqdm(
+                    pool.imap(self.read_tracer1, files), total=len(files), position=mpi_rank
+                    ))
         else:
             results = [self.read_tracer1(file) for file in files]
 
@@ -220,7 +222,7 @@ class Interface:
         globals.counter = multiprocessing.Value('i', 0)
         globals.lock = multiprocessing.Lock()
 
-    def run(self, healpix_ids=None):
+    def run(self, healpix_ids=None, mpi_rank=0):
         """Run the computation
 
         This can include the correlation function, the distortion matrix,
@@ -278,9 +280,12 @@ class Interface:
             if self.num_cpu > 1:
                 context = multiprocessing.get_context('fork')
                 with context.Pool(processes=self.num_cpu) as pool:
+                    num_pairs = pool.map(compute_num_pairs, healpix_ids)
+                    healpix_ids = healpix_ids[np.argsort(num_pairs)[::-1]]
+
                     results = list(tqdm.tqdm(
                         pool.imap_unordered(compute_xi_and_fisher, healpix_ids),
-                        total=len(healpix_ids)
+                        total=len(healpix_ids), position=mpi_rank
                     ))
 
                 for hp_id, res in results:
@@ -298,7 +303,7 @@ class Interface:
 
         # TODO: add other computations
 
-    def write_results(self):
+    def write_results(self, mpi_thread=None):
         if self.config['compute'].getboolean('compute-correlation', False):
             for healpix_id, result in self.xi_output.items():
                 self.output.write_cf_healpix(result, healpix_id, self.config, self.settings)
@@ -309,6 +314,8 @@ class Interface:
 
         if self.config['compute'].getboolean('compute-optimal-correlation', False):
             self.output.write_optimal_cf(
-                self.xi_est, self.fisher_est, self.optimal_xi_output, self.config, self.settings)
+                self.xi_est, self.fisher_est, self.optimal_xi_output, self.config, self.settings,
+                mpi_thread
+            )
 
         # TODO: add other modes

--- a/lya_2pt/interface.py
+++ b/lya_2pt/interface.py
@@ -303,7 +303,7 @@ class Interface:
 
         # TODO: add other computations
 
-    def write_results(self, mpi_thread=None):
+    def write_results(self, mpi_rank=None):
         if self.config['compute'].getboolean('compute-correlation', False):
             for healpix_id, result in self.xi_output.items():
                 self.output.write_cf_healpix(result, healpix_id, self.config, self.settings)
@@ -315,7 +315,7 @@ class Interface:
         if self.config['compute'].getboolean('compute-optimal-correlation', False):
             self.output.write_optimal_cf(
                 self.xi_est, self.fisher_est, self.optimal_xi_output, self.config, self.settings,
-                mpi_thread
+                mpi_rank
             )
 
         # TODO: add other modes

--- a/lya_2pt/optimal_estimator.py
+++ b/lya_2pt/optimal_estimator.py
@@ -222,3 +222,22 @@ def compute_xi_and_fisher(healpix_id):
         tracer1.release_inverse_covariance()
 
     return healpix_id, (xi_est, fisher_est)
+
+
+def compute_num_pairs(healpix_id):
+    hp_neighs = [other_hp for other_hp in globals.healpix_neighbours[healpix_id]
+                 if other_hp in globals.tracers2]
+    hp_neighs += [healpix_id]
+
+    num_pairs = int(0)
+    for tracer1 in globals.tracers1[healpix_id]:
+        potential_neighbours = [tracer2 for hp in hp_neighs for tracer2 in globals.tracers2[hp]]
+        neighbours, _ = tracer1.get_neighbours(
+                potential_neighbours, globals.auto_flag,
+                globals.z_min, globals.z_max,
+                globals.rp_max, globals.rt_max
+            )
+
+        num_pairs += len(neighbours)
+
+    return num_pairs

--- a/lya_2pt/output.py
+++ b/lya_2pt/output.py
@@ -185,7 +185,8 @@ class Output:
 
         results.close()
 
-    def write_optimal_cf(self, xi_est, fisher_est, output, global_config, settings):
+    def write_optimal_cf(self, xi_est, fisher_est, output, global_config, settings,
+                         mpi_thread=None):
         """Write computation output for the main healpix
 
         Arguments
@@ -196,7 +197,11 @@ class Output:
         file: str
         Name of the read file, used to construct the output file
         """
-        filename = self.healpix_dir / "optimal-correlation-all.fits.gz"
+        proc_string = ""
+        if mpi_thread is not None:
+            proc_string = "-" + str(mpi_thread)
+
+        filename = self.healpix_dir / f"opt-corr-mean{proc_string}.fits.gz"
 
         # save data
         output_fits = fitsio.FITS(filename, 'rw', clobber=True)
@@ -211,16 +216,22 @@ class Output:
             names=[correlation_name, "FISHER_MATRIX"],
             comment=['unnormalized correlation', 'Fisher matrix'],
             header=header,
-            extname='sum'
+            extname='MEAN_CORRELATION'
         )
-        # for healpix_id, result in output.items():
-        #     output_fits.write(
-        #         [result[0], result[1]],
-        #         names=[correlation_name, "FISHER_MATRIX"],
-        #         comment=['unnormalized correlation', 'Fisher matrix'],
-        #         header=header,
-        #         extname=str(healpix_id)
-        #     )
+
+        output_fits.close()
+
+        filename = self.healpix_dir / f"opt-corr-samples{proc_string}.fits.gz"
+        output_fits = fitsio.FITS(filename, 'rw', clobber=True)
+
+        for healpix_id, result in output.items():
+            output_fits.write(
+                [result[0], result[1]],
+                names=[correlation_name, "FISHER_MATRIX"],
+                comment=['unnormalized correlation', 'Fisher matrix'],
+                header=header,
+                extname=str(healpix_id)
+            )
 
         output_fits.close()
 

--- a/lya_2pt/output.py
+++ b/lya_2pt/output.py
@@ -185,8 +185,9 @@ class Output:
 
         results.close()
 
-    def write_optimal_cf(self, xi_est, fisher_est, output, global_config, settings,
-                         mpi_thread=None):
+    def write_optimal_cf(
+            self, xi_est, fisher_est, output, global_config, settings, mpi_rank=None
+    ):
         """Write computation output for the main healpix
 
         Arguments
@@ -198,8 +199,8 @@ class Output:
         Name of the read file, used to construct the output file
         """
         proc_string = ""
-        if mpi_thread is not None:
-            proc_string = "-" + str(mpi_thread)
+        if mpi_rank is not None:
+            proc_string = "-" + str(mpi_rank)
 
         filename = self.healpix_dir / f"opt-corr-mean{proc_string}.fits.gz"
 

--- a/lya_2pt/scripts/run_mpi.py
+++ b/lya_2pt/scripts/run_mpi.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import argparse
+import time
 from mpi4py import MPI
 from configparser import ConfigParser
 
@@ -43,11 +44,17 @@ def main():
         stop = int(start + num_tasks_per_proc)
 
     if mpi_rank == 0:
-        print('Starting computation...')
+        total_t1 = time.time()
+        print('Starting computation...', flush=True)
 
     lya2pt.read_tracers(lya2pt.files[start:stop])
-    lya2pt.run()
-    lya2pt.write_results()
+    lya2pt.run(mpi_rank=mpi_rank)
+    lya2pt.write_results(mpi_thread=mpi_rank)
+
+    if mpi_rank == 0:
+        total_t2 = time.time()
+        print(f'Total time: {(total_t2-total_t1):.3f} sec', flush=True)
+        print('Done', flush=True)
 
 
 if __name__ == '__main__':

--- a/lya_2pt/scripts/run_mpi.py
+++ b/lya_2pt/scripts/run_mpi.py
@@ -49,7 +49,7 @@ def main():
 
     lya2pt.read_tracers(lya2pt.files[start:stop])
     lya2pt.run(mpi_rank=mpi_rank)
-    lya2pt.write_results(mpi_thread=mpi_rank)
+    lya2pt.write_results(mpi_rank=mpi_rank)
 
     if mpi_rank == 0:
         total_t2 = time.time()

--- a/lya_2pt/utils.py
+++ b/lya_2pt/utils.py
@@ -1,5 +1,5 @@
 import os
-from os import mkdir
+from os import makedirs
 from pathlib import Path
 
 import numpy as np
@@ -140,5 +140,4 @@ def check_dir(dir: Path):
         dir: Path
             Directory to check
     """
-    if not dir.is_dir():
-        mkdir(dir)
+    makedirs(dir, exist_ok=True)


### PR DESCRIPTION
This is the version that ran on EDR with MPI.

Load balancing appears to work when using python multiprocessing. However, we need to do better when using MPI. The EDR run took ~1.5 hours on 4 nodes with 4 MPI processes and 256 threads each, but the fastest MPI thread finished in about 50 min. This means we have some waste. 

One option would be to read all the data on each MPI thread and do proper load balancing based on number of forest pairs. This would probably work well if each MPI process has at least a few threads.